### PR TITLE
Add Dockerfile and Fly.io deployment docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+data/
+things-cloud-mcp
+things-mcp
+.claude/
+.worktrees/
+fly.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+fly.toml
 things-mcp
 things-cloud-mcp
 cleanup-tool

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+
+ENV GOTOOLCHAIN=auto
+
+COPY . .
+RUN go mod download
+RUN go build -o things-mcp .
+
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /app/things-mcp /usr/local/bin/things-mcp
+
+EXPOSE 8080
+
+ENV PORT=8080
+
+CMD ["things-mcp"]

--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ A `Dockerfile` is included. To deploy on [Fly.io](https://fly.io):
 brew install flyctl
 fly auth login
 
-fly launch --no-deploy   # generates fly.toml — accepts defaults or customize
+fly launch --no-deploy                   # generates fly.toml — accepts defaults or customize
+fly volumes create data --size 1         # 1 GB persistent volume for tokens and JWT secret
 fly secrets set JWT_SECRET=$(openssl rand -hex 32)
 fly deploy
 ```
+
+**Important:** The persistent volume is required. Without it, OAuth tokens and the JWT signing secret are stored on the container's ephemeral disk and wiped on every restart or deploy, forcing all connected clients to re-authenticate.
 
 Your endpoint will be `https://<app-name>.fly.dev`. The default config (256 MB RAM, shared CPU, scale-to-zero) runs within Fly's free allowance.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this URL to your MCP client and start managing Things 3 tasks with AI. Multi
 
 If you prefer to host your own instance:
 
-```
+```bash
 go build -o things-mcp .
 ./things-mcp
 ```
@@ -26,5 +26,20 @@ The server listens on port 8080 by default (set `PORT` to override). Optionally 
 
 - OAuth clients (Claude.ai, ChatGPT) authenticate via the built-in OAuth 2.1 flow
 - CLI clients (Claude Code, Cursor, Windsurf) use Basic auth headers
+
+### Deploy to Fly.io
+
+A `Dockerfile` is included. To deploy on [Fly.io](https://fly.io):
+
+```bash
+brew install flyctl
+fly auth login
+
+fly launch --no-deploy   # generates fly.toml — accepts defaults or customize
+fly secrets set JWT_SECRET=$(openssl rand -hex 32)
+fly deploy
+```
+
+Your endpoint will be `https://<app-name>.fly.dev`. The default config (256 MB RAM, shared CPU, scale-to-zero) runs within Fly's free allowance.
 
 Built with [things-cloud-sdk](https://github.com/arthursoares/things-cloud-sdk) and [mcp-go](https://github.com/mark3labs/mcp-go).


### PR DESCRIPTION
## Summary

- Adds a `Dockerfile` for building a minimal Alpine-based container image
- Documents Fly.io deployment steps in the README
- Gitignores `fly.toml` since it's generated per-user by `fly launch`

## Test plan

- [ ] `docker build` produces a working image
- [ ] `fly launch --no-deploy` + `fly secrets set JWT_SECRET=...` + `fly deploy` produces a working endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)