### PR TITLE
fix: prevent EXC_BREAKPOINT crash in Things by clamping sort index >= 1

### DIFF
--- a/main.go
+++ b/main.go
@@ -348,18 +348,44 @@ func offsetToTime(secs int) string {
 // Index helpers — find the minimum ix among siblings so new items sort to top
 // ---------------------------------------------------------------------------
 
+// nextTopIndexBelow returns a sort index strictly less than minIx, clamped to
+// be >= 1. Use this when computing the `ix` for a new item that should sort
+// above all existing siblings. Things' sync engine crashes
+// (LegacySCHistoryPerformSync EXC_BREAKPOINT brk 1, Swift precondition) when
+// processing a Task6 item with a non-positive sort index during incremental
+// history pulls — so this helper guarantees a safe value regardless of what
+// minIndexWhere returns. Centralising the clamp here means future callers
+// cannot reintroduce the negative-ix bug by forgetting the guard at the
+// call site.
+func nextTopIndexBelow(minIx int) int {
+	if minIx-1 < 1 {
+		return 1
+	}
+	return minIx - 1
+}
+
 // minIndexWhere returns the minimum Index among tasks matching the predicate.
+// Uses a large starting value so that any real task index (always positive in
+// Things) is found as the true minimum. Falls back to 1 when no tasks match
+// or when state is uninitialised.
 func (t *ThingsMCP) minIndexWhere(match func(*thingscloud.Task) bool) int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	minIx := 0
 	if t.state == nil {
-		return minIx
+		return 1
 	}
+	minIx := 1 << 30 // larger than any real Things sort index
+	found := false
 	for _, task := range t.state.Tasks {
-		if match(task) && task.Index < minIx {
-			minIx = task.Index
+		if match(task) {
+			if !found || task.Index < minIx {
+				minIx = task.Index
+				found = true
+			}
 		}
+	}
+	if !found {
+		return 1
 	}
 	return minIx
 }
@@ -3033,7 +3059,7 @@ func (t *ThingsMCP) handleCreateTask(_ context.Context, req mcp.CallToolRequest)
 	}
 
 	// Compute ix so the new task sorts to the top among siblings
-	ix := t.minSiblingIndex(opts["project_uuid"], opts["heading_uuid"]) - 1
+	ix := nextTopIndexBelow(t.minSiblingIndex(opts["project_uuid"], opts["heading_uuid"]))
 
 	taskUUID := generateUUID()
 	payload := newTaskCreatePayload(title, opts, ix)
@@ -3085,7 +3111,7 @@ func (t *ThingsMCP) handleCreateProject(_ context.Context, req mcp.CallToolReque
 		}
 	}
 
-	ix := t.minProjectIndex(opts["area_uuid"]) - 1
+	ix := nextTopIndexBelow(t.minProjectIndex(opts["area_uuid"]))
 
 	projectUUID := generateUUID()
 	payload := newTaskCreatePayload(title, opts, ix)
@@ -3113,7 +3139,7 @@ func (t *ThingsMCP) handleCreateHeading(_ context.Context, req mcp.CallToolReque
 		return errResult(err.Error()), nil
 	}
 
-	ix := t.minHeadingIndex(projectUUID) - 1
+	ix := nextTopIndexBelow(t.minHeadingIndex(projectUUID))
 
 	headingUUID := generateUUID()
 	payload := newTaskCreatePayload(title, opts, ix)


### PR DESCRIPTION
Fixes #16.

## What's wrong

`minIndexWhere()` initialises `minIx := 0` and only tracks tasks whose `Index < minIx`. Since real Things tasks always have positive `Index` values, no task ever satisfies that condition and the function always returns `0`. Callers then compute `0 - 1 = -1` for the first MCP-created task, `-1 - 1 = -2` for the next, and so on.

When Things' macOS or iOS app pulls these `Task6` items via the incremental history sync (`LegacySCHistoryPerformSync`), it hits a Swift precondition (`brk 1`) on the negative sort index and crashes on launch — repeatedly, every time, until the offending entries are removed from the cloud history.

See the linked issue for the full crash report, reproduction steps, and the legacy-account angle that explains why this hasn't been reported before.

## Changes

- **`minIndexWhere`**: replace `minIx := 0` with `1 << 30` so the loop finds the actual minimum among matching tasks. Falls back to `1` (not `0`) when no matching tasks exist.
- **`nextTopIndexBelow(minIx int) int`**: new helper that takes the result of `minIndexWhere` and returns `minIx - 1` clamped to `>= 1`.
- **Call sites** (`handleCreateTask`, `handleCreateProject`, `handleCreateHeading`): use `nextTopIndexBelow` instead of inline `min - 1` arithmetic. Removes per-site arithmetic and ensures future callers can't reintroduce the bug.

## Test plan

- [x] Verified locally on a freshly-created Things Cloud account: `things_create_task` now writes `ix = 1` instead of `ix = -1`.
- [x] No regression in the placement intent: new items still sort to the top of their sibling list (siblings just collide on `ix = 1` once the cascade reaches that floor — Things tolerates collisions and falls back to creation order).
- [ ] Maintainer to verify in their own environment.