### PR TITLE
Guard task updates against a pre-existing non-positive sort index

### DIFF
--- a/main.go
+++ b/main.go
@@ -1137,11 +1137,58 @@ func (t *ThingsMCP) syncAndRebuild() error {
 	return err
 }
 
+// minSortIndex is the smallest sort index Things tolerates. Things' sync
+// engine (LegacySCHistoryPerformSync) crashes with an EXC_BREAKPOINT Swift
+// precondition when it processes a Task6 history commit for an item whose sort
+// index (ix) is non-positive.
+const minSortIndex = 1
+
+// healNonPositiveIndex guards every Task6 update against that crash. Some
+// legacy items carry a non-positive ix in the cloud baseline; editing one
+// re-emits it into a fresh commit and trips the precondition on every syncing
+// device, taking down the Mac and iOS apps until the cloud is repaired — even
+// when the edit itself (e.g. a trash) never touches ix. For each Task6 update
+// being written this ensures the item's resulting ix is >= minSortIndex: it
+// clamps an explicitly-set ix, and otherwise repairs an item whose currently
+// stored ix is non-positive by injecting a safe ix into the same commit, so
+// the commit leaves the item in a state Things can process. Item creation
+// clamps separately at the source via nextTopIndexBelow.
+func (t *ThingsMCP) healNonPositiveIndex(items []thingscloud.Identifiable) {
+	state := t.getState()
+	for _, it := range items {
+		we, ok := it.(writeEnvelope)
+		if !ok || we.kind != "Task6" || we.action != 1 {
+			continue
+		}
+		p, ok := we.payload.(map[string]any)
+		if !ok {
+			continue
+		}
+		if raw, set := p["ix"]; set {
+			// Clamp an explicitly-written index (e.g. a reorder) to a safe value.
+			if iv, ok := raw.(int); ok && iv < minSortIndex {
+				p["ix"] = minSortIndex
+			}
+			continue
+		}
+		// No ix in this commit: repair the item if its stored ix is non-positive.
+		if state == nil {
+			continue
+		}
+		if task, ok := state.Tasks[we.id]; ok && task.Index < minSortIndex {
+			p["ix"] = minSortIndex
+		}
+	}
+}
+
 func (t *ThingsMCP) writeAndSync(items ...thingscloud.Identifiable) error {
 	// Pre-write: sync remote changes and update LatestServerIndex for ancestor-index
 	if err := t.incrementalSync(); err != nil {
 		return fmt.Errorf("pre-write sync: %w", err)
 	}
+	// Guard against the Things sync-engine crash on non-positive sort indexes,
+	// using the state just refreshed by the pre-write sync.
+	t.healNonPositiveIndex(items)
 	if err := t.history.Write(items...); err != nil {
 		return err
 	}

--- a/pure_test.go
+++ b/pure_test.go
@@ -7,7 +7,43 @@ import (
 	"time"
 
 	thingscloud "github.com/arthursoares/things-cloud-sdk"
+	memory "github.com/arthursoares/things-cloud-sdk/state/memory"
 )
+
+// TestHealNonPositiveIndex covers the guard against the Things sync-engine
+// EXC_BREAKPOINT crash: any Task6 update touching an item with a non-positive
+// sort index must leave that item's ix >= minSortIndex.
+func TestHealNonPositiveIndex(t *testing.T) {
+	state := memory.NewState()
+	state.Tasks["poison"] = &thingscloud.Task{UUID: "poison", Index: -5388}
+	state.Tasks["healthy"] = &thingscloud.Task{UUID: "healthy", Index: 12}
+	tmcp := newTestThingsMCPDirect(state)
+
+	// Trash an item carrying a legacy negative ix (the real incident): the
+	// commit sets no ix, so the guard must inject a clamped one.
+	trash := writeEnvelope{id: "poison", action: 1, kind: "Task6", payload: map[string]any{"tr": true}}
+	// Editing a healthy item must not add an ix it didn't have.
+	edit := writeEnvelope{id: "healthy", action: 1, kind: "Task6", payload: map[string]any{"tt": "x"}}
+	// An explicitly-written non-positive ix (e.g. a reorder) must be clamped.
+	move := writeEnvelope{id: "healthy", action: 1, kind: "Task6", payload: map[string]any{"ix": -7}}
+	// Creates (action 0) own their clamping at the source; leave them untouched.
+	create := writeEnvelope{id: "new", action: 0, kind: "Task6", payload: map[string]any{"ix": -1}}
+
+	tmcp.healNonPositiveIndex([]thingscloud.Identifiable{trash, edit, move, create})
+
+	if got := trash.payload.(map[string]any)["ix"]; got != minSortIndex {
+		t.Errorf("trash of poison item: ix = %v, want %d", got, minSortIndex)
+	}
+	if _, set := edit.payload.(map[string]any)["ix"]; set {
+		t.Errorf("edit of healthy item: ix should not be injected")
+	}
+	if got := move.payload.(map[string]any)["ix"]; got != minSortIndex {
+		t.Errorf("explicit negative ix: ix = %v, want %d", got, minSortIndex)
+	}
+	if got := create.payload.(map[string]any)["ix"]; got != -1 {
+		t.Errorf("create action: ix = %v, want -1 (untouched)", got)
+	}
+}
 
 // ---------------------------------------------------------------------------
 // parseDate


### PR DESCRIPTION
I ran into this with some old tasks in my Things database that carry a negative sort index. When I trashed a batch of them through this MCP, Things started crashing on every device on sync, and stayed down until I repaired the cloud data.

I worked out the fix and this description with Claude Code, and I've been running the guard on my own deployment.

## What this fixes

Editing or trashing a task through the MCP can crash the Things apps on every synced device if that task already has a non-positive sort index (`ix`).

Things' sync engine hits a Swift precondition failure (`EXC_BREAKPOINT` in `LegacySCHistoryPerformSync`) when it processes a history commit for a Task6 item whose `ix` is zero or negative. The failure sits on the sync-processing path, not on local reads, so an item with a bad index can go unnoticed for a long time: once every device has synced past the commit that set it, nothing re-processes it. The next edit to that item writes a new history commit; every device processes that commit on its next sync, and they all crash.

## Why the existing clamp doesn't catch it

#16 added a clamp so newly created items always get `ix >= 1`. That stops the MCP from writing a bad index, but only on the create path. It doesn't help when you edit an item that already has a bad index, such as:

- items created by older Things versions or other tools, and
- items this MCP created before the #16 clamp landed.

Trashing makes this easy to trigger, because a trash sets no `ix` (it just flips `tr`), yet it still re-emits the item into a fresh commit with its existing bad index intact.

## The change

`healNonPositiveIndex` runs in `writeAndSync` before each write. For every Task6 update it:

- clamps an explicitly written `ix` to `>= 1`, and
- when the update sets no `ix`, injects a safe `ix` if the item's stored index is non-positive.

Either way the resulting commit leaves the item with an index Things can process. This covers all task-update paths (edit, move, recurrence). Item creation keeps its existing clamp.

## Testing

`TestHealNonPositiveIndex` covers four cases:

- trashing an item with a negative stored index (the real failure case): the commit gains a clamped `ix`,
- editing a healthy item: no `ix` is added,
- an explicitly negative `ix`: clamped,
- a create action: left untouched.

The full test suite passes.

## Scope

This is an edge case: you only hit it if you already have items with a non-positive index. But the failure is severe (every device crashes until the cloud data is repaired) and hard to trace, since the crash surfaces on a later edit, far from the write that planted the bad index. The guard is cheap, so it's worth closing the gap alongside #16 and sparing the next person the diagnosis.
