### PR TITLE
Stop hiding untitled tasks that have a note

### DIFF
--- a/main.go
+++ b/main.go
@@ -1542,11 +1542,14 @@ func isRecurringTemplate(task *thingscloud.Task) bool {
 	return task.Repeater != nil
 }
 
-// isUntitledTask returns true if the task has no real title. Things sometimes
-// retains shells of tasks created and abandoned without ever being typed into;
-// these are not actionable items and should be hidden from list queries.
+// isUntitledTask returns true if the task has no real title and no note.
+// Things sometimes retains shells of tasks created and abandoned without
+// ever being typed into; these are not actionable items and should be
+// hidden from list queries. A blank title with a real note (e.g. a link
+// or text saved via a share extension that never got a title typed in) is
+// still actionable, so it is not considered untitled.
 func isUntitledTask(task *thingscloud.Task) bool {
-	return strings.TrimSpace(task.Title) == ""
+	return strings.TrimSpace(task.Title) == "" && strings.TrimSpace(task.Note) == ""
 }
 
 // ---------------------------------------------------------------------------

--- a/main.go
+++ b/main.go
@@ -1256,11 +1256,14 @@ func isRecurringTemplate(task *thingscloud.Task) bool {
 	return task.Repeater != nil
 }
 
-// isUntitledTask returns true if the task has no real title. Things sometimes
-// retains shells of tasks created and abandoned without ever being typed into;
-// these are not actionable items and should be hidden from list queries.
+// isUntitledTask returns true if the task has no real title and no note.
+// Things sometimes retains shells of tasks created and abandoned without
+// ever being typed into; these are not actionable items and should be
+// hidden from list queries. A blank title with a real note (e.g. a link
+// or text saved via a share extension that never got a title typed in) is
+// still actionable, so it is not considered untitled.
 func isUntitledTask(task *thingscloud.Task) bool {
-	return strings.TrimSpace(task.Title) == ""
+	return strings.TrimSpace(task.Title) == "" && strings.TrimSpace(task.Note) == ""
 }
 
 // ---------------------------------------------------------------------------

--- a/pure_test.go
+++ b/pure_test.go
@@ -444,3 +444,32 @@ func TestOffsetToTime(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// isUntitledTask
+// ---------------------------------------------------------------------------
+
+func TestIsUntitledTask(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		note  string
+		want  bool
+	}{
+		{"no title, no note", "", "", true},
+		{"whitespace title, no note", "   ", "", true},
+		{"has title, no note", "Buy milk", "", false},
+		{"no title, has note", "", "https://example.com", false},
+		{"whitespace title, whitespace note", " ", "  ", true},
+		{"has title, has note", "Buy milk", "2%", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &thingscloud.Task{Title: tt.title, Note: tt.note}
+			if got := isUntitledTask(task); got != tt.want {
+				t.Errorf("isUntitledTask(title=%q, note=%q) = %v, want %v", tt.title, tt.note, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`isUntitledTask()` currently hides any task with a blank title from
every list endpoint (`find_tasks`, headings, projects, today/upcoming),
treating a blank title as a sign the task is an abandoned shell that
was never typed into.

This PR narrows that check: a task is only treated as untitled when
**both** its title and its note are empty.

## Why

In practice, plenty of blank-title tasks carry a real note — a link
or snippet saved via a share extension or quick-capture flow that
never got a title typed in. These are actionable items, but the
current filter makes them invisible to every query, including
`find_tasks` and even the debug/raw-inspection paths, since those all
build from the same filtered task list. There's no way for a client
of this MCP server to discover or retitle them.

## Change

```go
func isUntitledTask(task *thingscloud.Task) bool {
-	return strings.TrimSpace(task.Title) == ""
+	return strings.TrimSpace(task.Title) == "" && strings.TrimSpace(task.Note) == ""
}
```

Tasks with no title and no note (the genuine abandoned-shell case)
are still hidden, unchanged from today's behavior.

## Testing

- Added `TestIsUntitledTask` covering blank/whitespace title and note
  combinations
- `go build ./...` and `go test ./...` pass locally