### PR TITLE
fix: support Task7 kind and skip unknown items during rebuild

### DIFF
--- a/main.go
+++ b/main.go
@@ -2086,7 +2086,7 @@ func (t *ThingsMCP) handleDiagnose(email, password string) *diagReport {
 			if ierr == nil {
 				var newestDate time.Time
 				for _, item := range items {
-					if item.Kind != thingscloud.ItemKindTask {
+					if item.Kind != thingscloud.ItemKindTask && item.Kind != thingscloud.ItemKindTask7 {
 						continue
 					}
 					var payload thingscloud.TaskActionItemPayload
@@ -2295,7 +2295,7 @@ func (t *ThingsMCP) diagnoseSteps4to7(history *thingscloud.History, report *diag
 		}
 		for _, item := range allItems[tailStart:] {
 			ti := tailItem{Kind: string(item.Kind), Action: int(item.Action)}
-			if item.Kind == thingscloud.ItemKindTask {
+			if item.Kind == thingscloud.ItemKindTask || item.Kind == thingscloud.ItemKindTask7 {
 				var payload thingscloud.TaskActionItemPayload
 				if uerr := json.Unmarshal(item.P, &payload); uerr == nil {
 					if payload.CreationDate != nil {

--- a/things-cloud-sdk/state/memory/memory.go
+++ b/things-cloud-sdk/state/memory/memory.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	// "fmt"
 	"sort"
 
@@ -304,7 +305,7 @@ func (s *State) Update(items ...things.Item) error {
 		}
 		var target any
 		switch rawItem.Kind {
-		case things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+		case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
 			target = &things.TaskActionItemPayload{}
 		case things.ItemKindChecklistItem, things.ItemKindChecklistItem2, things.ItemKindChecklistItem3:
 			target = &things.CheckListActionItemPayload{}
@@ -315,7 +316,13 @@ func (s *State) Update(items ...things.Item) error {
 		case things.ItemKindTombstone, things.ItemKindTombstonePlain:
 			target = &things.TombstoneActionItemPayload{}
 		default:
-			return fmt.Errorf("item %s has unsupported kind %q", rawItem.UUID, rawItem.Kind)
+			// An item kind the SDK doesn't model yet (e.g. a new Things
+			// release introducing a new object type) must not take down
+			// every read/write for the whole account. Skip it and move
+			// on — mirrors the resilience sync/process.go already has via
+			// UnknownChange, applied here to the state-rebuild path.
+			log.Printf("state: skipping item %s with unrecognized kind %q", rawItem.UUID, rawItem.Kind)
+			continue
 		}
 		if err := json.Unmarshal(rawItem.P, target); err != nil {
 			return fmt.Errorf("decode item %s (%s): %w", rawItem.UUID, rawItem.Kind, err)
@@ -331,7 +338,7 @@ func (s *State) Update(items ...things.Item) error {
 			rawItem.UUID = things.EncodeLegacyIdentifier(rawItem.UUID)
 		}
 		switch rawItem.Kind {
-		case things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+		case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
 			item := things.TaskActionItem{Item: rawItem}
 			_ = json.Unmarshal(rawItem.P, &item.P)
 			if legacy {

--- a/things-cloud-sdk/state/memory/memory_test.go
+++ b/things-cloud-sdk/state/memory/memory_test.go
@@ -287,6 +287,48 @@ func TestState_Update(t *testing.T) {
 	})
 }
 
+func TestState_Update_Task7(t *testing.T) {
+	t.Run("Create Task via Task7 kind", func(t *testing.T) {
+		s := NewState()
+		if err := s.Update(things.Item{
+			Action: things.ItemActionCreated,
+			Kind:   things.ItemKindTask7,
+			P:      json.RawMessage(newTaskPayload),
+		}); err != nil {
+			t.Fatal(err.Error())
+		}
+
+		if len(s.Tasks) != 1 {
+			t.Fatal("Expected a Task7 item to decode into a task, same as Task6")
+		}
+	})
+}
+
+func TestState_Update_UnrecognizedKind(t *testing.T) {
+	t.Run("skips unknown kind without aborting the rest of the batch", func(t *testing.T) {
+		s := NewState()
+		err := s.Update(
+			things.Item{
+				Action: things.ItemActionCreated,
+				Kind:   things.ItemKind("Command"),
+				P:      json.RawMessage(`{}`),
+			},
+			things.Item{
+				Action: things.ItemActionCreated,
+				Kind:   things.ItemKindTask,
+				P:      json.RawMessage(newTaskPayload),
+			},
+		)
+		if err != nil {
+			t.Fatalf("expected an unrecognized kind to be skipped rather than error, got: %v", err)
+		}
+
+		if len(s.Tasks) != 1 {
+			t.Fatal("expected the known task after the unrecognized item to still be applied")
+		}
+	})
+}
+
 func TestState_Tombstone(t *testing.T) {
 	t.Parallel()
 
@@ -495,16 +537,20 @@ func TestStateUpdateRejectsMalformedKnownItem(t *testing.T) {
 	}
 }
 
-func TestStateUpdateRejectsUnknownKind(t *testing.T) {
+// This test originally used "Task7" as its example of a hypothetical future
+// kind that should be rejected. Things 3.23 then introduced a real Task7 item
+// kind for repeating tasks (see TestState_Update_Task7), so an item kind the
+// SDK genuinely doesn't recognize yet needs its own placeholder name here.
+func TestStateUpdateSkipsUnknownKind(t *testing.T) {
 	s := NewState()
 	err := s.Update(things.Item{
 		UUID:   "future-item",
-		Kind:   things.ItemKind("Task7"),
+		Kind:   things.ItemKind("SomeFutureKind"),
 		Action: things.ItemActionCreated,
 		P:      []byte(`{}`),
 	})
-	if err == nil {
-		t.Fatal("expected unknown kind error")
+	if err != nil {
+		t.Fatalf("expected unrecognized kind to be skipped rather than error, got: %v", err)
 	}
 }
 

--- a/things-cloud-sdk/sync/process.go
+++ b/things-cloud-sdk/sync/process.go
@@ -65,7 +65,7 @@ func (s *Syncer) processItem(item things.Item, serverIndex int, ts time.Time) ([
 		return nil, nil
 	}
 	switch item.Kind {
-	case things.ItemKindTask, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
+	case things.ItemKindTask, things.ItemKindTask7, things.ItemKindTask4, things.ItemKindTask3, things.ItemKindTaskPlain:
 		return s.processTaskItem(item, serverIndex, ts)
 	case things.ItemKindArea, things.ItemKindArea3, things.ItemKindAreaPlain:
 		return s.processAreaItem(item, serverIndex, ts)

--- a/things-cloud-sdk/types.go
+++ b/things-cloud-sdk/types.go
@@ -59,6 +59,12 @@ var (
 	ItemKindChecklistItem2 ItemKind = "ChecklistItem2"
 	ItemKindChecklistItem3 ItemKind = "ChecklistItem3"
 	// ItemKindTask identifies a Task or Subtask
+	// ItemKindTask7 is the schema Things 3.23 ("Repeating To-Dos,
+	// Refined") writes for repeating tasks. Its payload appears to be a
+	// superset of Task6's — decoded here as the same TaskActionItemPayload
+	// shape, so any fields the SDK doesn't model yet are simply ignored by
+	// json.Unmarshal rather than causing a decode failure.
+	ItemKindTask7     ItemKind = "Task7"
 	ItemKindTask      ItemKind = "Task6"
 	ItemKindTask4     ItemKind = "Task4"
 	ItemKindTask3     ItemKind = "Task3"


### PR DESCRIPTION
## Summary
Things 3.23 ("Repeating To-Dos, Refined", 2026-08-19) started writing
repeating tasks as a new item kind, `Task7`, which the SDK's state
rebuild didn't recognize. A single `Task7` item aborted the entire
rebuild, taking down every tool call for the account, including
`things_diagnose` itself.

- `Task7` is now decoded the same as `Task6` wherever tasks are
  handled — its payload appears to be a superset, so fields the SDK
  doesn't model are simply ignored by `json.Unmarshal` rather than
  causing a decode failure.
- Independently, an item kind the SDK still doesn't recognize is now
  skipped with a log line instead of aborting the whole rebuild,
  matching the resilience `sync/process.go` already has via
  `UnknownChange`. A future Things release introducing yet another
  kind should degrade gracefully instead of taking every tool down
  again.

Fixes #23.

## Test plan
- [x] `TestState_Update_Task7` — Task7 items decode into `state.Tasks`
- [x] `TestState_Update_UnrecognizedKind` — unknown kind skipped, rest
      of batch still applies
- [x] `TestStateUpdateSkipsUnknownKind` (renamed/updated from
      `TestStateUpdateRejectsUnknownKind`, which had used `"Task7"` as
      its placeholder example before it became a real kind)
- [x] Full suite green: `go test ./...`
- [x] Verified against a live Things Cloud account with real Task7
      items (517 repeating tasks): `things_diagnose` went from
      hard-failing on every call to 0 warnings, newest task no longer
      frozen