### PR TITLE
fix(diagnose): return empty arrays, never null

### DIFF
--- a/main.go
+++ b/main.go
@@ -1962,10 +1962,21 @@ func extractCredentials(ctx context.Context, um *UserManager) (string, string, e
 // Diagnostic handler: steps 1-3
 // ---------------------------------------------------------------------------
 
+// newDiagReport returns a report whose slices are empty rather than nil. The
+// tool declares steps, warnings and errors as arrays in its output schema and
+// the MCP client validates against it — a nil slice marshals to `null`, which
+// fails validation and rejects the whole call. That made diagnose unusable on
+// exactly the accounts that had nothing to report. Every other handler already
+// guards this (see handleFindAreas); this constructor keeps the guarantee in
+// one place so a new early return cannot lose it.
+func newDiagReport() *diagReport {
+	return &diagReport{Steps: []diagStep{}, Warnings: []string{}, Errors: []string{}}
+}
+
 func (t *ThingsMCP) handleDiagnose(email, password string) *diagReport {
-	report := &diagReport{}
-	var allWarnings []string
-	var allErrors []string
+	report := newDiagReport()
+	allWarnings := []string{}
+	allErrors := []string{}
 
 	// Step 1: credential_verification
 	step1 := diagStep{

--- a/pure_test.go
+++ b/pure_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"hash/crc32"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,10 +16,10 @@ import (
 
 func TestParseDate(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  string
+		name    string
+		input   string
 		wantNil bool
-		check  func(t *testing.T, got *time.Time)
+		check   func(t *testing.T, got *time.Time)
 	}{
 		{
 			name:  "YYYY-MM-DD returns UTC midnight",
@@ -442,5 +443,35 @@ func TestOffsetToTime(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic report shape
+// ---------------------------------------------------------------------------
+
+// A healthy account produces no warnings and no errors — and that is precisely
+// the case that used to break. The output schema declares these fields as
+// arrays, the MCP client validates against it, and a nil slice marshals to
+// `null`, so the client rejected the whole response:
+//
+//	Invalid structured content returned by tool things_diagnose:
+//	None is not of type 'array'
+//
+// The tool for debugging sync problems therefore failed on every account that
+// had nothing to report.
+func TestDiagReportMarshalsEmptyArraysNotNull(t *testing.T) {
+	raw, err := json.Marshal(newDiagReport())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(raw)
+	for _, want := range []string{`"steps":[]`, `"warnings":[]`, `"errors":[]`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %s in %s", want, got)
+		}
+	}
+	if strings.Contains(got, "null") {
+		t.Errorf("no field may marshal to null — the schema declares arrays: %s", got)
 	}
 }


### PR DESCRIPTION
`things_diagnose` fails for every account that has nothing to report:

```
Invalid structured content returned by tool things_diagnose: None is not of type 'array'
Failed validating 'type' in schema['properties']['data']['properties']['errors']:
{'items': {'type': 'string'}, 'type': 'array'}
On instance['data']['errors']: None
```

## Cause

`handleDiagnose` builds its report as `&diagReport{}` and collects into:

```go
var allWarnings []string
var allErrors   []string
```

A run with no warnings and no errors leaves both nil, and a nil slice marshals to `null`. `outputSchemaFor("things_diagnose")` declares `steps`, `warnings` and `errors` as arrays and marks them required, so the MCP client rejects the entire response.

**The healthier the account, the more reliably the diagnostic tool fails** — and it is the tool you reach for when sync misbehaves. That is presumably why it went unnoticed: it only surfaces once nothing else is wrong.

## Fix

Every other handler already guards this:

```go
if areas == nil {
    areas = []AreaOutput{}
}
```

Same in `handleFindTags`, `handleFindProjects` and `handleFindHeadings`. `handleDiagnose` was the one place that missed it.

The guarantee now lives in `newDiagReport()` rather than at the call site, because three early returns already assign `report.Warnings` / `report.Errors` and a fourth must not be able to lose it.

## How it surfaced

After applying #24 locally. With `Task7` handled, diagnose finally got far enough to return a result at all — and then failed on its own output schema. The two are unrelated, but #23 masked this one completely.

## Test

`TestDiagReportMarshalsEmptyArraysNotNull` asserts `"steps":[]`, `"warnings":[]`, `"errors":[]` and that no field marshals to `null`. It fails against the current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
